### PR TITLE
Improve MainView

### DIFF
--- a/Applications/GoodMacAppIcon/Sources/MainView.swift
+++ b/Applications/GoodMacAppIcon/Sources/MainView.swift
@@ -53,7 +53,7 @@ struct MainView: View {
                     Circle()
                         .frame(height: 20.0)
                         .foregroundColor(goodAppIconProbability >= 0.5 ? .green : .red)
-                    Text(String(format: "%0.4f%%", goodAppIconProbability * 100))
+                    Text(goodAppIconProbability, format: .percent.precision(.fractionLength(4)))
                         .font(.largeTitle)
                         .bold()
                 }

--- a/Applications/GoodMacAppIcon/Sources/MainView.swift
+++ b/Applications/GoodMacAppIcon/Sources/MainView.swift
@@ -37,11 +37,11 @@ struct MainView: View {
                         .frame(width: 128.0, height: 128.0)
                         .padding(40.0)
                         .background {
-                            RoundedRectangle(cornerRadius: 20.0)
+                            RoundedRectangle(cornerRadius: 48.0, style: .continuous)
                                 .stroke(style: StrokeStyle(
                                     lineWidth: 8.0,
                                     lineCap: .round,
-                                    dash: [10.0, 22.0]
+                                    dash: [10.0, 20.0]
                                 ))
                         }
                         .foregroundStyle(isDropTargeted ? .secondary : .tertiary)

--- a/Applications/GoodMacAppIcon/Sources/MainView.swift
+++ b/Applications/GoodMacAppIcon/Sources/MainView.swift
@@ -33,7 +33,6 @@ struct MainView: View {
                     Image("app")
                         .resizable()
                         .renderingMode(.template)
-                        .foregroundStyle(.white)
                         .scaledToFit()
                         .frame(width: 128.0, height: 128.0)
                         .padding(40.0)
@@ -45,7 +44,7 @@ struct MainView: View {
                                     dash: [10.0, 22.0]
                                 ))
                         }
-                        .opacity(isDropTargeted ? 0.8 : 0.4)
+                        .foregroundStyle(isDropTargeted ? .secondary : .tertiary)
                 }
             }
             if let goodAppIconProbability {


### PR DESCRIPTION
This PR contains the following two changes:

1. Make the rounded corners of the app symbol outline the same as the template for the macOS app icons.
2. Fix the app symbol in the Light mode (Otherwise, you'll get the view below when the system is  in the Light mode).
<img width="499" alt="Screenshot 2024-06-07 at 20 36 11" src="https://github.com/niw/GoodMacAppIcon/assets/1165044/ea53af9d-3d9a-4fda-b2bf-740a77dfafa7">
